### PR TITLE
add fsnotify version notes to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ $ cd live-ghci
 $ make
 ```
 
-You may have to install some packages with `cabal install package_name`. A binary will be produced in `./bin/live-ghci`. Copy or symlink it into your PATH.
+You may have to install some packages with `cabal install package_name`. You will need `fsnotify 0.3.0.0` or higher. Installing this package with older versions of `fsnotify` may result in type errors.
+
+A binary will be produced in `./bin/live-ghci`. Copy or symlink it into your PATH.
 
 Then in your Haskell project directory, start Live GHCi as follows:
 


### PR DESCRIPTION
When trying to install this today following your README, I had type errors regarding an incorrect number of arguments to `FSNotify.Modified`. This appears to be due to `cabal install fsnotify` installing `fsnotify-0.2.1.1` in which `Modified` did indeed only take two arguments. 

Once I installed `fsnotify-0.3.0.1`, it compiled and `make` worked. It might be helpful if the docs made this clear. 